### PR TITLE
Keyboard navigation and F11 fullscreen

### DIFF
--- a/Godot Project/Scenes/Levels/AcidLevel/acid_level.tscn
+++ b/Godot Project/Scenes/Levels/AcidLevel/acid_level.tscn
@@ -144,13 +144,6 @@ tile_map_data = PackedByteArray("AAAAAAAAAAABAAMAAAD//wAAAAABAAMAAAD+/wAAAAABAAM
 [node name="Player" parent="." index="8"]
 position = Vector2(-56, 0)
 
-[node name="Camera2D" parent="Player" index="6"]
-position_smoothing_enabled = false
-
-[node name="CoyoteTimer" parent="Player" index="7"]
-wait_time = 0.08
-one_shot = true
-
 [node name="EndLocator" parent="." index="9"]
 position = Vector2(-90, -289)
 
@@ -263,6 +256,11 @@ shape = SubResource("RectangleShape2D_ebixy")
 [connection signal="player_died" from="AcidTiles/AcidTile4Long/AcidTile4Long3" to="." method="_on_player_died"]
 [connection signal="player_died" from="AcidTiles/AcidTile4Long/AcidTile4Long3/AcidTile4Long" to="." method="_on_player_died"]
 [connection signal="player_died" from="AcidTiles/AcidTile4Long/AcidTile4Long3/AcidTile4Long/AcidTile4Long" to="." method="_on_player_died"]
+[connection signal="player_died" from="AcidTiles/AcidTile4Long2" to="." method="_on_player_died"]
+[connection signal="player_died" from="AcidTiles/AcidTile4Long2/AcidTile4Long3" to="." method="_on_player_died"]
+[connection signal="player_died" from="AcidTiles/AcidTile4Long2/AcidTile4Long3/AcidTile4Long4" to="." method="_on_player_died"]
+[connection signal="player_died" from="AcidTiles/AcidTile4Long2/AcidTile4Long3/AcidTile4Long4/AcidTile4Long3" to="." method="_on_player_died"]
+[connection signal="spike_trap_player_died" from="SpikeTrap2" to="." method="_on_player_died"]
 [connection signal="spike_trap_player_died" from="SpikeTrap" to="." method="_on_player_died"]
 [connection signal="player_died" from="FloorMaw" to="." method="_on_player_died"]
 [connection signal="player_died" from="FloorMaw2" to="." method="_on_player_died"]

--- a/Godot Project/Scenes/Levels/Tutorial/tutorial.gd
+++ b/Godot Project/Scenes/Levels/Tutorial/tutorial.gd
@@ -22,6 +22,8 @@ func _jump_to_end() -> void:
 	player.global_position = end_locator.global_position;
 
 func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		SettingsManager.toggle_fullscreen();
 	if event.is_action_pressed("pause"):
 		pause_menu_popup.open();
 

--- a/Godot Project/Scenes/Levels/template_level.gd
+++ b/Godot Project/Scenes/Levels/template_level.gd
@@ -26,6 +26,8 @@ func _jump_to_end() -> void:
 	player.global_position = end_locator.global_position;
 
 func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		SettingsManager.toggle_fullscreen();
 	if event.is_action_pressed("pause"):
 		pause_menu_popup.open();
 

--- a/Godot Project/Scenes/Menus/main_menu.gd
+++ b/Godot Project/Scenes/Menus/main_menu.gd
@@ -5,6 +5,7 @@ signal game_resume_requested;
 
 @onready var resume_button: Button = $MainMenuParent/MarginContainer/VBoxContainer/ResumeButton
 @onready var settings_menu: Control = $SettingsMenu
+@onready var options_button: Button = $MainMenuParent/MarginContainer/VBoxContainer/OptionsButton
 
 func _ready() -> void:
 	# Starting point for keyboard navigation.
@@ -19,6 +20,12 @@ func _on_resume_button_pressed() -> void:
 func _on_options_button_pressed():
 	settings_menu.show();
 
-
 func _on_quit_button_pressed():
 	get_tree().quit();
+
+func _on_settings_menu_hidden() -> void:
+	options_button.grab_focus();
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		SettingsManager.toggle_fullscreen();

--- a/Godot Project/Scenes/Menus/main_menu.tscn
+++ b/Godot Project/Scenes/Menus/main_menu.tscn
@@ -79,3 +79,4 @@ layout_mode = 1
 [connection signal="pressed" from="MainMenuParent/MarginContainer/VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]
 [connection signal="pressed" from="MainMenuParent/MarginContainer/VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]
 [connection signal="pressed" from="MainMenuParent/MarginContainer/VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]
+[connection signal="hidden" from="SettingsMenu" to="." method="_on_settings_menu_hidden"]

--- a/Godot Project/Scenes/Menus/pause_menu_popup.gd
+++ b/Godot Project/Scenes/Menus/pause_menu_popup.gd
@@ -2,9 +2,12 @@ extends Window
 
 signal main_menu_requested;
 @onready var settings_menu: Control = $SettingsMenu
+@onready var resume_button: Button = $PauseMenu/MarginContainer/VBoxContainer/ResumeButton
+@onready var settings_button: Button = $PauseMenu/MarginContainer/VBoxContainer/SettingsButton
 
 func open() -> void:
 	get_tree().paused = true;
+	resume_button.grab_focus();
 	show();
 
 func close() -> void:
@@ -25,6 +28,8 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("pause"):
 		close();
 
-
 func _on_settings_button_pressed() -> void:
 	settings_menu.show();
+
+func _on_settings_menu_hidden() -> void:
+	settings_button.grab_focus();

--- a/Godot Project/Scenes/Menus/pause_menu_popup.tscn
+++ b/Godot Project/Scenes/Menus/pause_menu_popup.tscn
@@ -63,18 +63,34 @@ label_settings = SubResource("LabelSettings_t5ul8")
 
 [node name="ResumeButton" type="Button" parent="PauseMenu/MarginContainer/VBoxContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../QuitButton")
+focus_neighbor_bottom = NodePath("../MenuButton")
+focus_next = NodePath("../MenuButton")
+focus_previous = NodePath("../QuitButton")
 text = "Resume"
 
 [node name="MenuButton" type="Button" parent="PauseMenu/MarginContainer/VBoxContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../ResumeButton")
+focus_neighbor_bottom = NodePath("../SettingsButton")
+focus_next = NodePath("../SettingsButton")
+focus_previous = NodePath("../ResumeButton")
 text = "Main Menu"
 
 [node name="SettingsButton" type="Button" parent="PauseMenu/MarginContainer/VBoxContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../MenuButton")
+focus_neighbor_bottom = NodePath("../QuitButton")
+focus_next = NodePath("../QuitButton")
+focus_previous = NodePath("../MenuButton")
 text = "Settings"
 
 [node name="QuitButton" type="Button" parent="PauseMenu/MarginContainer/VBoxContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../SettingsButton")
+focus_neighbor_bottom = NodePath("../ResumeButton")
+focus_next = NodePath("../ResumeButton")
+focus_previous = NodePath("../SettingsButton")
 text = "Quit Game"
 
 [node name="SettingsMenu" parent="." instance=ExtResource("3_5luvi")]
@@ -85,3 +101,4 @@ visible = false
 [connection signal="pressed" from="PauseMenu/MarginContainer/VBoxContainer/MenuButton" to="." method="_on_main_menu_button_pressed"]
 [connection signal="pressed" from="PauseMenu/MarginContainer/VBoxContainer/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="pressed" from="PauseMenu/MarginContainer/VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]
+[connection signal="hidden" from="SettingsMenu" to="." method="_on_settings_menu_hidden"]

--- a/Godot Project/Scenes/Menus/settings_menu.gd
+++ b/Godot Project/Scenes/Menus/settings_menu.gd
@@ -1,11 +1,14 @@
 extends Control
 
 @onready var fullscreen_button: CheckButton = $MarginContainer/VBoxContainer/FullscreenButton
+@onready var return_button: Button = $MarginContainer/VBoxContainer/ReturnButton
 
 func _on_return_button_pressed() -> void:
 	hide();
 
-
 func _on_visibility_changed() -> void:
+	if return_button != null:
+		if visible:
+			return_button.grab_focus();
 	if fullscreen_button != null:
 		fullscreen_button._update();

--- a/Godot Project/Scenes/Menus/settings_menu.tscn
+++ b/Godot Project/Scenes/Menus/settings_menu.tscn
@@ -36,6 +36,7 @@ scale = Vector2(3.6, 3.6)
 texture = ExtResource("1_anrnc")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 0
 offset_left = 452.0
 offset_top = 231.0
 offset_right = 714.0

--- a/Godot Project/Scenes/Menus/settings_menu.tscn
+++ b/Godot Project/Scenes/Menus/settings_menu.tscn
@@ -65,6 +65,10 @@ vertical_alignment = 2
 [node name="VolumeSlider" type="HSlider" parent="MarginContainer/VBoxContainer/VBoxContainer"]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
+focus_neighbor_top = NodePath("../../ReturnButton")
+focus_neighbor_bottom = NodePath("../../FullscreenButton")
+focus_next = NodePath("../../FullscreenButton")
+focus_previous = NodePath("../../ReturnButton")
 max_value = 1.0
 step = 0.05
 tick_count = 11
@@ -80,11 +84,19 @@ horizontal_alignment = 3
 
 [node name="FullscreenButton" type="CheckButton" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../VBoxContainer/VolumeSlider")
+focus_neighbor_bottom = NodePath("../ReturnButton")
+focus_next = NodePath("../ReturnButton")
+focus_previous = NodePath("../VBoxContainer/VolumeSlider")
 text = "Fullscreen"
 script = ExtResource("4_s6qnc")
 
 [node name="ReturnButton" type="Button" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../FullscreenButton")
+focus_neighbor_bottom = NodePath("../VBoxContainer/VolumeSlider")
+focus_next = NodePath("../VBoxContainer/VolumeSlider")
+focus_previous = NodePath("../FullscreenButton")
 text = "Back"
 
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]

--- a/Godot Project/project.godot
+++ b/Godot Project/project.godot
@@ -96,7 +96,6 @@ toggle_double_jump={
 fullscreen={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194342,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/Godot Project/project.godot
+++ b/Godot Project/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 globall="*res://scripts/global.gd"
+SettingsManager="*res://settings_manager.gd"
 
 [display]
 
@@ -90,6 +91,12 @@ toggle_dash={
 toggle_double_jump={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194333,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+fullscreen={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194342,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/Godot Project/settings_manager.gd
+++ b/Godot Project/settings_manager.gd
@@ -1,0 +1,8 @@
+extends Node
+
+
+func toggle_fullscreen() -> void:
+	if DisplayServer.window_get_mode() == DisplayServer.WINDOW_MODE_FULLSCREEN:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED);
+	else:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN);


### PR DESCRIPTION
Keyboard navigation now works in all menus including pause and settings.
Fullscreen can be toggled from anywhere using F11.
Also connected some death signals that I had forgotten in the acid level.