### PR TITLE
Path Unlocking

### DIFF
--- a/Godot Project/Scenes/Entities/HeartCore/heart_core.gd
+++ b/Godot Project/Scenes/Entities/HeartCore/heart_core.gd
@@ -1,0 +1,33 @@
+extends AnimatedSprite2D
+
+signal defeated;
+
+@onready var immunity_time: Timer = $ImmunityTime
+
+var player_in_range: bool = false;
+var health: int = 1;
+
+func _on_player_detection_zone_body_entered(body: Node2D) -> void:
+	if body.has_method("player"):
+		print("in range")
+		player_in_range = true 
+
+
+func _on_player_detection_zone_body_exited(body: Node2D) -> void:
+	if body.has_method("player"):
+		player_in_range = false;
+
+
+func _process(_delta: float) -> void:
+	if Global.player_current_attack && player_in_range && immunity_time.is_stopped():
+		immunity_time.start()
+		health -= 1;
+	if health <= 0:
+		kill_self();
+
+
+func kill_self():
+	defeated.emit();
+	Global.core_one_defeated = true;
+	print("Core defeated");
+	self.queue_free();

--- a/Godot Project/Scenes/Entities/HeartCore/heart_core.tscn
+++ b/Godot Project/Scenes/Entities/HeartCore/heart_core.tscn
@@ -1,0 +1,93 @@
+[gd_scene load_steps=13 format=3 uid="uid://dyp8unn4irhq"]
+
+[ext_resource type="Texture2D" uid="uid://crh4qnkw227o0" path="res://Scenes/Levels/LevelAssets/core_animation.png" id="1_8xgss"]
+[ext_resource type="Script" path="res://Scenes/Entities/HeartCore/heart_core.gd" id="2_0yemp"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wd6p5"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(0, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5kiib"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(64, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_xuepq"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(128, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fej2a"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(192, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_87cdn"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(256, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_56gew"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(320, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4cp8j"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(384, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_hkk6c"]
+atlas = ExtResource("1_8xgss")
+region = Rect2(448, 0, 64, 64)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_vkoga"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_wd6p5")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5kiib")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_xuepq")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fej2a")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_87cdn")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_56gew")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4cp8j")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_hkk6c")
+}],
+"loop": true,
+"name": &"pulse",
+"speed": 5.0
+}]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_eb3y5"]
+size = Vector2(100, 66)
+
+[node name="HeartCore" type="AnimatedSprite2D"]
+texture_filter = 1
+position = Vector2(0, -32)
+sprite_frames = SubResource("SpriteFrames_vkoga")
+animation = &"pulse"
+autoplay = "pulse"
+frame_progress = 0.843793
+script = ExtResource("2_0yemp")
+
+[node name="PlayerDetectionZone" type="Area2D" parent="."]
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerDetectionZone"]
+position = Vector2(0, -1)
+shape = SubResource("RectangleShape2D_eb3y5")
+
+[node name="ImmunityTime" type="Timer" parent="."]
+one_shot = true
+
+[connection signal="body_entered" from="PlayerDetectionZone" to="." method="_on_player_detection_zone_body_entered"]
+[connection signal="body_exited" from="PlayerDetectionZone" to="." method="_on_player_detection_zone_body_exited"]

--- a/Godot Project/Scenes/Levels/Hub/hub_level.tscn
+++ b/Godot Project/Scenes/Levels/Hub/hub_level.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=4 uid="uid://dg0inc6rsa7g2"]
+[gd_scene load_steps=8 format=4 uid="uid://dg0inc6rsa7g2"]
 
 [ext_resource type="PackedScene" uid="uid://djgqihrehhe1h" path="res://Scenes/Levels/template_level.tscn" id="1_w8r22"]
 [ext_resource type="AudioStream" uid="uid://da84ipv4fccu5" path="res://Scenes/Audio/Music/Start and Area 1.ogg" id="2_hrdhi"]
+[ext_resource type="PackedScene" uid="uid://ccb205jld20es" path="res://Scenes/Levels/LevelComponents/Barrier.tscn" id="3_shbf4"]
 
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_j7r1s"]
 
@@ -52,3 +53,6 @@ tile_map_data = PackedByteArray("AAAAAAAAAAABAAMAAAABAAAAAAABAAMAAAACAAAAAAABAAM
 
 [node name="EndLocator" parent="." index="8"]
 position = Vector2(539, -225)
+
+[node name="Barrier" parent="." index="9" instance=ExtResource("3_shbf4")]
+position = Vector2(-88, -240)

--- a/Godot Project/Scenes/Levels/LevelComponents/Barrier.tscn
+++ b/Godot Project/Scenes/Levels/LevelComponents/Barrier.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=3 uid="uid://ccb205jld20es"]
+
+[ext_resource type="TileSet" uid="uid://d3uaft5ba4k5r" path="res://Scenes/Levels/LevelAssets/gore_tileset.tres" id="1_5bp8b"]
+[ext_resource type="Script" path="res://Scenes/Levels/LevelComponents/barrier.gd" id="1_hlddw"]
+
+[node name="Barrier" type="Node2D"]
+script = ExtResource("1_hlddw")
+
+[node name="TileMapLayer" type="TileMapLayer" parent="."]
+tile_map_data = PackedByteArray(0, 0, 0, 0, 255, 255, 0, 0, 5, 0, 3, 0, 0, 0)
+tile_set = ExtResource("1_5bp8b")

--- a/Godot Project/Scenes/Levels/LevelComponents/barrier.gd
+++ b/Godot Project/Scenes/Levels/LevelComponents/barrier.gd
@@ -1,10 +1,26 @@
 extends Node2D
 
+enum UnlockCondition {
+	CORE_ONE,
+	CORE_TWO,
+	NEVER,
+}
 
+## Remove self after this miniboss is defeated.
+@export
+var unlock_after: UnlockCondition;
+
+## Attach signal here to remove immediately after a miniboss is defeated
 func _on_heart_core_defeated() -> void:
 	self.queue_free();
 
 
+## If the selected core has been defeated then remove this barrier while loading level.
 func _ready() -> void:
-	if Global.core_one_defeated:
-		self.queue_free();
+	match unlock_after:
+		UnlockCondition.CORE_ONE:
+			if Global.core_one_defeated:
+				self.queue_free();
+		UnlockCondition.CORE_TWO:
+			if Global.core_two_defeated:
+				self.queue_free();

--- a/Godot Project/Scenes/Levels/LevelComponents/barrier.gd
+++ b/Godot Project/Scenes/Levels/LevelComponents/barrier.gd
@@ -1,0 +1,10 @@
+extends Node2D
+
+
+func _on_heart_core_defeated() -> void:
+	self.queue_free();
+
+
+func _ready() -> void:
+	if Global.core_one_defeated:
+		self.queue_free();

--- a/Godot Project/Scenes/Levels/integrated_core.tscn
+++ b/Godot Project/Scenes/Levels/integrated_core.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=4 uid="uid://d2be2xo822iaj"]
+[gd_scene load_steps=13 format=4 uid="uid://d2be2xo822iaj"]
 
 [ext_resource type="PackedScene" uid="uid://djgqihrehhe1h" path="res://Scenes/Levels/template_level.tscn" id="1_tjl8h"]
 [ext_resource type="AudioStream" uid="uid://dyfnr5yu66yck" path="res://Scenes/Audio/Music/Miniboss.mp3" id="2_e3kep"]
@@ -6,7 +6,8 @@
 [ext_resource type="PackedScene" uid="uid://b4gjkiteju2ea" path="res://Scenes/Entities/RibBug/rib_bug.tscn" id="3_a8spc"]
 [ext_resource type="PackedScene" uid="uid://ddk74kjxma2c1" path="res://Scenes/Entities/Floor Maw/floor_maw.tscn" id="4_cexib"]
 [ext_resource type="PackedScene" uid="uid://dmdvwelqe4h1u" path="res://Scenes/Entities/Spike Trap/spike_trap.tscn" id="5_3xakp"]
-[ext_resource type="Texture2D" uid="uid://crh4qnkw227o0" path="res://Scenes/Levels/LevelAssets/core_animation.png" id="6_djkpx"]
+[ext_resource type="PackedScene" uid="uid://dyp8unn4irhq" path="res://Scenes/Entities/HeartCore/heart_core.tscn" id="7_bcxry"]
+[ext_resource type="PackedScene" uid="uid://ccb205jld20es" path="res://Scenes/Levels/LevelComponents/Barrier.tscn" id="8_0yblf"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_v1qaj"]
 size = Vector2(59, 15)
@@ -19,72 +20,6 @@ size = Vector2(20, 42)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xuvhy"]
 size = Vector2(77, 20)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wd6p5"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(0, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_5kiib"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(64, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_xuepq"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(128, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fej2a"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(192, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_87cdn"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(256, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_56gew"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(320, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4cp8j"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(384, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_hkk6c"]
-atlas = ExtResource("6_djkpx")
-region = Rect2(448, 0, 64, 64)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_vkoga"]
-animations = [{
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_wd6p5")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_5kiib")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_xuepq")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_fej2a")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_87cdn")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_56gew")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_4cp8j")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_hkk6c")
-}],
-"loop": true,
-"name": &"pulse",
-"speed": 5.0
-}]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_7inm1"]
 
 [node name="TemplateLevel2" instance=ExtResource("1_tjl8h")]
 previous_level = "AcidLevel/acid_level.tscn"
@@ -209,22 +144,16 @@ rotation = 1.5708
 position = Vector2(227, -384)
 rotation = 3.14159
 
-[node name="HeartCore" type="AnimatedSprite2D" parent="." index="10"]
-texture_filter = 1
-position = Vector2(71, -999)
-sprite_frames = SubResource("SpriteFrames_vkoga")
-animation = &"pulse"
-autoplay = "pulse"
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="HeartCore" index="0"]
-position = Vector2(0.999996, 0)
-scale = Vector2(2.03123, 3.04)
-shape = SubResource("RectangleShape2D_7inm1")
+[node name="HeartCore" parent="." index="10" instance=ExtResource("7_bcxry")]
+position = Vector2(74, -992)
 
 [node name="Player" parent="." index="11"]
 position = Vector2(329, 285)
 
-[node name="EndLocator" parent="." index="12"]
+[node name="Barrier" parent="." index="12" instance=ExtResource("8_0yblf")]
+position = Vector2(-68, -992)
+
+[node name="EndLocator" parent="." index="13"]
 position = Vector2(-185, -977)
 
 [connection signal="player_died" from="Enemies/FloorMaw" to="." method="_on_player_died"]
@@ -232,3 +161,4 @@ position = Vector2(-185, -977)
 [connection signal="player_died" from="Enemies/FloorMaw3" to="." method="_on_player_died"]
 [connection signal="player_died" from="Enemies/FloorMaw4" to="." method="_on_player_died"]
 [connection signal="player_died" from="Enemies/FloorMaw5" to="." method="_on_player_died"]
+[connection signal="defeated" from="HeartCore" to="Barrier" method="_on_heart_core_defeated"]

--- a/Godot Project/Scenes/Levels/template_level.tscn
+++ b/Godot Project/Scenes/Levels/template_level.tscn
@@ -34,7 +34,7 @@ zoom = Vector2(2.5, 2.5)
 position_smoothing_speed = 13.0
 
 [node name="CoyoteTimer" type="Timer" parent="Player"]
-wait_time = 0.08
+wait_time = 0.12
 one_shot = true
 
 [node name="EndLocator" type="Node2D" parent="."]

--- a/Godot Project/Scenes/game_manager.gd
+++ b/Godot Project/Scenes/game_manager.gd
@@ -19,6 +19,9 @@ var DEFAULT_SAVE: Dictionary = {
 	"double jump": false,
 	"dash": false,
 	"speedrun enabled": false,
+	"speedrun time": 0,
+	"core one defeated": false,
+	"core two defeated": false,
 }
 
 var SAVE_KEYS: Array = [
@@ -27,7 +30,10 @@ var SAVE_KEYS: Array = [
 	'camera smoothing',
 	'double jump',
 	'dash',
-	'speedrun enabled'
+	'speedrun enabled',
+	"speedrun time",
+	"core one defeated",
+	"core two defeated"
 ]
 
 var current_level: Node;
@@ -64,8 +70,11 @@ func save_game() -> void:
 		"fullscreen": SettingsManager.is_fullscreen(),
 		"camera smoothing": SettingsManager.camera_smoothing,
 		"speedrun enabled": SettingsManager.speedrun_timer,
+		"speedrun time": Global.speedrun_time,
 		"double jump": Abilities.double_jump_enabled,
 		"dash": Abilities.dash_enabled,
+		"core one defeated": Global.core_one_defeated,
+		"core two defeated": Global.core_two_defeated,
 	}
 	var serialised_data = JSON.stringify(save_data);
 	var file = FileAccess.open(GAME_SAVE_PATH, FileAccess.WRITE);
@@ -111,6 +120,9 @@ func apply_save(data: Dictionary) -> String:
 	Abilities.double_jump_enabled    = data["double jump"];
 	Abilities.dash_enabled           = data["dash"];
 	SettingsManager.speedrun_timer   = data["speedrun enabled"];
+	Global.speedrun_time             = data["speedrun time"];
+	Global.core_one_defeated         = data["core one defeated"];
+	Global.core_two_defeated         = data["core two defeated"];
 	print(data['current_level'])
 	return data["current_level"];
 

--- a/Godot Project/scripts/global.gd
+++ b/Godot Project/scripts/global.gd
@@ -6,3 +6,6 @@ var checkpoint_reached: bool = false
 var checkpoint_position: Vector2 = Vector2(0, 0)
 
 var speedrun_time: float = 0
+
+var core_one_defeated: bool = false;
+var core_two_defeated: bool = false;


### PR DESCRIPTION
The exits at the end of miniboss levels can now be unlocked when the miniboss is defeated.

Barriers now have a dropdown menu in the inspector which lets you
decide when they should be unlocked.
For example, if CoreOne is selected then the barrier will remove itself
after core one has been defeated.

Status of each core is now part of the save file.